### PR TITLE
Potential fix for code scanning alert no. 23: Potential use after free

### DIFF
--- a/pisalib/pisa_engine.cpp
+++ b/pisalib/pisa_engine.cpp
@@ -1869,7 +1869,7 @@ namespace pisa  {
 
 
   int Assembler::NoteMultimer ( int r )  {
-  PPMultimerSet US;
+  PPMultimerSet US, oldMultSet;
   int            i,k;
 
     //  1. Check that obtained set of multimers is a new one
@@ -1884,13 +1884,14 @@ namespace pisa  {
 
       if (nMultSets>=nMultSetAlloc)  {
         nMultSetAlloc += 100;
+        oldMultSet = multSet;
         US = new PMultimerSet[nMultSetAlloc];
         for (i=0;i<nMultSets;i++)
-          US[i] = multSet[i];
+          US[i] = oldMultSet[i];
         for (i=nMultSets;i<nMultSetAlloc;i++)
           US[i] = NULL;
-        delete[] multSet;
         multSet = US;
+        delete[] oldMultSet;
       }
 
       if (!multSet[nMultSets])  multSet[nMultSets] = new MultimerSet();


### PR DESCRIPTION
Potential fix for [https://github.com/PDBe-KB/pisa/security/code-scanning/23](https://github.com/PDBe-KB/pisa/security/code-scanning/23)

General fix: avoid deleting the old buffer before the class pointer is safely switched to a new valid buffer. Keep old storage alive until after reassignment succeeds, then free old storage via a saved pointer.

Best targeted fix in `pisalib/pisa_engine.cpp` (inside `Assembler::NoteMultimer`, around lines 1885–1894):
- Introduce a temporary pointer (e.g., `PPMultimerSet oldMultSet`) to hold the previous `multSet`.
- Allocate and fill `US` as now.
- Assign `multSet = US` first.
- Then `delete[] oldMultSet`.
This preserves behavior while removing the risky “delete then later use class pointer” pattern that static analysis flags.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
