### PR TITLE
Potential fix for code scanning alert no. 19: Potential use after free

### DIFF
--- a/mmdb2/mmdb_xml_.cpp
+++ b/mmdb2/mmdb_xml_.cpp
@@ -540,23 +540,24 @@ namespace mmdb  {
     }
 
     void  XMLObject::AddObject ( PXMLObject XMLObject, int lenInc )  {
-    PPXMLObject obj1;
+    PPXMLObject obj1, oldObject;
     int         i;
 
       if (!XMLObject)  return;
 
       if (nObjects>=nAlloc)  {
+        if (lenInc<=0)  lenInc = 1;
         nAlloc += lenInc;
         obj1 = new PXMLObject[nAlloc];
         for (i=0;i<nObjects;i++)
           obj1[i] = object[i];
         for (i=nObjects;i<nAlloc;i++)
           obj1[i] = NULL;
-        if (object)  delete[] object;
-        object = obj1;
+        oldObject = object;
+        object    = obj1;
+        if (oldObject)  delete[] oldObject;
       }
 
-      if (object[nObjects])  delete object[nObjects];
       object[nObjects] = XMLObject;
       XMLObject->SetParent ( this );
       nObjects++;


### PR DESCRIPTION
Potential fix for [https://github.com/PDBe-KB/pisa/security/code-scanning/19](https://github.com/PDBe-KB/pisa/security/code-scanning/19)

Use a safer reallocation pattern in `XMLObject::AddObject` that avoids deleting the old buffer until after a successful allocation and initialization, and guard against non-positive `lenInc` so capacity always grows. Also avoid deleting `object[nObjects]` before overwrite, because this slot is expected to be free and deleting it can be unsafe if stale/corrupted.

Best fix in this file/region:
- In `mmdb2/mmdb_xml_.cpp`, inside `XMLObject::AddObject` (around lines 542–563):
  1. Ensure `lenInc >= 1` before using it to grow `nAlloc`.
  2. Allocate `obj1`, copy existing entries, initialize the rest to `NULL`.
  3. Swap pointers using a temporary `oldObject`, then `delete[] oldObject`.
  4. Remove `if (object[nObjects]) delete object[nObjects];` and directly assign into the new slot.
This preserves functionality (append child object) while eliminating the flagged UAF pattern and improving robustness.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
